### PR TITLE
Ajusta la configuración de seguridad y scripts del login

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -48,22 +48,7 @@
   </div>
 
   <!-- Script -->
-  <script>
-    document.getElementById('loginForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = Object.fromEntries(new FormData(e.target).entries());
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data)
-      });
-      if (res.ok) {
-        window.location.href = '/index.html';
-      } else {
-        alert('Credenciales incorrectas');
-      }
-    });
-  </script>
+  <script src="/login.js" defer></script>
 
 </body>
 </html>

--- a/public/login.js
+++ b/public/login.js
@@ -1,0 +1,29 @@
+(function () {
+  const form = document.getElementById('loginForm');
+  if (!form) {
+    return;
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const data = Object.fromEntries(new FormData(event.target).entries());
+
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (response.ok) {
+        window.location.href = '/index.html';
+        return;
+      }
+
+      alert('Credenciales incorrectas');
+    } catch (error) {
+      console.error('Error al intentar iniciar sesión:', error);
+      alert('No se pudo procesar la solicitud. Intente nuevamente más tarde.');
+    }
+  });
+})();

--- a/server.js
+++ b/server.js
@@ -69,7 +69,26 @@ app.use(
   })
 );
 
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", 'https://cdn.tailwindcss.com'],
+        connectSrc: ["'self'"],
+        imgSrc: ["'self'", 'data:'],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        fontSrc: ["'self'", 'data:'],
+        objectSrc: ["'none'"],
+        baseUri: ["'self'"],
+        formAction: ["'self'"],
+      },
+    },
+    crossOriginOpenerPolicy: false,
+    crossOriginEmbedderPolicy: false,
+    originAgentCluster: false,
+  })
+);
 app.use(express.json());
 app.use(ensureLoggedIn);
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
## Resumen
- Configura Helmet con una política de seguridad de contenido que admite el CDN de Tailwind y desactiva cabeceras que causaban advertencias en entornos sin HTTPS.
- Traslada la lógica del formulario de inicio de sesión a un script externo y refuerza el manejo de errores del envío.

## Pruebas
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6e7fc83fc8325b9fd8408f9b1f9b9