### PR TITLE
Fix user update endpoint and enhance search filtering

### DIFF
--- a/middlewares/usuariosValidation.js
+++ b/middlewares/usuariosValidation.js
@@ -7,7 +7,10 @@ const crearUsuarioValidator = [
 ];
 
 const modificarUsuarioValidator = [
-  body('username').notEmpty().withMessage('El nombre de usuario es obligatorio'),
+  body('username')
+    .if((value, { req }) => !req.params.username)
+    .notEmpty()
+    .withMessage('El nombre de usuario es obligatorio'),
   body('email').optional({ checkFalsy: true }).isEmail().withMessage('Email no válido'),
 ];
 

--- a/routes/usuarios.js
+++ b/routes/usuarios.js
@@ -24,6 +24,13 @@ router.post(
   validar,
   usuariosController.modificarUsuario
 );
+router.put(
+  '/:username',
+  auth,
+  modificarUsuarioValidator,
+  validar,
+  usuariosController.modificarUsuario
+);
 router.post('/wp-password-change', wpToken, usuariosController.passwordCambiadaDesdeWp);
 router.post('/estado', auth, usuariosController.cambiarEstado);
 router.get('/roles_suite', auth, usuariosController.obtenerRolesSuite);


### PR DESCRIPTION
## Summary
- allow modifying users via the RESTful route and ensure the controller uses the username from the URL when it is not in the payload
- trim and validate updated fields while syncing external systems and logging password changes for modifications
- improve user listing filters by correcting pagination parsing and searching by additional columns

## Testing
- npm test -- --runTestsByPath controllers/usuariosController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd7ece67b88325a3f9a26e1361ddce